### PR TITLE
WmSettingsTwig

### DIFF
--- a/src/Twig/WmSettingsTwig.php
+++ b/src/Twig/WmSettingsTwig.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\wmsettings\Twig;
+
+use Drupal\wmsettings\Service\WmSettings;
+
+/**
+ * Class WmSettingsTwig
+ * @package Drupal\wmsettings\Twig
+ */
+class WmSettingsTwig extends \Twig_Extension
+{
+    /** @var WmSettings */
+    protected $wmSettings;
+
+    /**
+     * WmSettingsTwig constructor.
+     *
+     * @param \Drupal\wmsettings\Service\WmSettings $wmSettings
+     */
+    public function __construct(WmSettings $wmSettings)
+    {
+        $this->wmSettings = $wmSettings;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'wmsettings.twig_extension.wmsettings';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('wmsettings', array($this, 'wmsettings'), array(
+                'is_safe' => array('html'),
+                'needs_environment' => false,
+                'needs_context' => false,
+                'is_variadic' => false,
+            )),
+        );
+    }
+
+    /**
+     * Hopefully returning the model of the settings bundle.
+     * @param $settings
+     *
+     * @return mixed
+     */
+    public function wmsettings($settings)
+    {
+        return $this->wmSettings->read($settings);
+    }
+}

--- a/wmsettings.services.yml
+++ b/wmsettings.services.yml
@@ -2,8 +2,16 @@ services:
   wmsettings.settings:
     class: Drupal\wmsettings\Service\WmSettings
     arguments: ['@entity.manager', '@entity_type.manager', '@entity.query', '@language_manager', '@config.factory', '@entity.repository']
+
   wmsettings.config_subscriber:
     class: Drupal\wmsettings\EventSubscriber\ConfigSubscriber
     arguments: ['@wmsettings.settings']
     tags:
       - { name: event_subscriber }
+
+  wmsettings.twig.wmsettings:
+    class: Drupal\wmsettings\Twig\WmSettingsTwig
+    arguments:
+      - @wmsettings.settings
+    tags:
+      - { name: twig.extension }


### PR DESCRIPTION
Add a twig extension to get the settings on the go.

Makes things very easy, this extension return the settings bundle, which if you have been a good boy is returning a model. Thus you can then use the settings direct in the twig.

ex,
```
{{ wmsettings('homepage').getHeaderImage()|imgix('1080p') }}
```