### PR TITLE
Add static cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## [0.7.4] - 2021-08-24
+### Added
+- Add a static cache to the `WmSettings` service
+
 ## [0.7.3] - 2021-06-17
 ### Changed
 - Redirect to settings overview after saving, when having navigated to the settings edit form through the menu items


### PR DESCRIPTION
Drops the amount of queries drastically. At a big news site we did 312 queries on the homepage. Dropped it to 148 by adding a static cache here..

Meaning we did this query 164 times 🙈 