### PR TITLE
Drupal 13 compatibility: replace deprecated check_markup(); declare DeleteForm::$id

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "drupal/core": "^9.2 || ^10.0 || ^11.0"
+        "drupal/core": "^10.1 || ^11.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.0",

--- a/src/Form/DeleteForm.php
+++ b/src/Form/DeleteForm.php
@@ -12,6 +12,8 @@ class DeleteForm extends ConfirmFormBase
 {
     /** @var WmSettings */
     protected $wmSettings;
+    /** @var string|null */
+    protected $id;
 
     public static function create(ContainerInterface $container)
     {

--- a/src/Service/WmSettings.php
+++ b/src/Service/WmSettings.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\wmsettings\Service;
 
+use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
@@ -38,13 +39,15 @@ class WmSettings
         EntityRepositoryInterface $entityRepository,
         LanguageManagerInterface $languageManager,
         ConfigFactoryInterface $configFactory,
-        RendererInterface $renderer
+        ?RendererInterface $renderer = null
     ) {
         $this->entityTypeBundleInfo = $entityTypeBundleInfo;
         $this->entityTypeManager = $entityTypeManager;
         $this->entityRepository = $entityRepository;
         $this->languageManager = $languageManager;
-        $this->renderer = $renderer;
+        // Falling back keeps subclasses and swapped service definitions that
+        // do not pass the new argument working.
+        $this->renderer = $renderer ?? \Drupal::service('renderer');
         $this->config = $configFactory->get('wmsettings.settings');
         $this->configEditable = $configFactory->getEditable('wmsettings.settings');
     }
@@ -234,7 +237,12 @@ class WmSettings
                             '#text' => $value['value'],
                             '#format' => $value['format'],
                         ];
-                        $return[$field_name] = $this->renderer->renderInIsolation($build);
+                        $return[$field_name] = DeprecationHelper::backwardsCompatibleCall(
+                            \Drupal::VERSION,
+                            '10.3',
+                            fn () => $this->renderer->renderInIsolation($build),
+                            fn () => $this->renderer->renderPlain($build),
+                        );
                         break;
                     case 'textfield':
                         $return[$field_name] = $entity->get($field_name)->getString();

--- a/src/Service/WmSettings.php
+++ b/src/Service/WmSettings.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\link\Plugin\Field\FieldType\LinkItem;
 
 class WmSettings
@@ -22,6 +23,8 @@ class WmSettings
     protected $entityRepository;
     /** @var LanguageManagerInterface */
     protected $languageManager;
+    /** @var RendererInterface */
+    protected $renderer;
     /** @var ImmutableConfig */
     protected $config;
     /** @var Config */
@@ -34,12 +37,14 @@ class WmSettings
         EntityTypeManagerInterface $entityTypeManager,
         EntityRepositoryInterface $entityRepository,
         LanguageManagerInterface $languageManager,
-        ConfigFactoryInterface $configFactory
+        ConfigFactoryInterface $configFactory,
+        RendererInterface $renderer
     ) {
         $this->entityTypeBundleInfo = $entityTypeBundleInfo;
         $this->entityTypeManager = $entityTypeManager;
         $this->entityRepository = $entityRepository;
         $this->languageManager = $languageManager;
+        $this->renderer = $renderer;
         $this->config = $configFactory->get('wmsettings.settings');
         $this->configEditable = $configFactory->getEditable('wmsettings.settings');
     }
@@ -224,11 +229,12 @@ class WmSettings
                 switch ($type) {
                     case 'textarea':
                         $value = $entity->get($field_name)->first()->getValue();
-                        // TODO: Dep inject renderer here.
-                        $return[$field_name] = check_markup(
-                            $value['value'],
-                            $value['format']
-                        );
+                        $build = [
+                            '#type' => 'processed_text',
+                            '#text' => $value['value'],
+                            '#format' => $value['format'],
+                        ];
+                        $return[$field_name] = $this->renderer->renderInIsolation($build);
                         break;
                     case 'textfield':
                         $return[$field_name] = $entity->get($field_name)->getString();

--- a/wmsettings.info.yml
+++ b/wmsettings.info.yml
@@ -1,7 +1,7 @@
 name: Wieni Settings
 type: module
 description: Provides an Editor UI and Developer API for managing custom settings
-core_version_requirement: ^9.2 || ^10 | ^11
+core_version_requirement: ^10.1 || ^11
 package: Wieni
 dependencies:
   - options

--- a/wmsettings.services.yml
+++ b/wmsettings.services.yml
@@ -7,6 +7,7 @@ services:
             - '@entity.repository'
             - '@language_manager'
             - '@config.factory'
+            - '@renderer'
 
     wmsettings.config_subscriber:
         class: Drupal\wmsettings\EventSubscriber\ConfigSubscriber


### PR DESCRIPTION
## Summary
- **`WmSettings::fill()`** (textarea case): `check_markup()` is deprecated in drupal:11.4.0 and removed in drupal:13.0.0. Replaced with a `#type => processed_text` render array rendered through `DeprecationHelper::backwardsCompatibleCall()` ([change record](https://www.drupal.org/node/3379306)): `renderInIsolation()` on core ≥10.3, `renderPlain()` below. Behaviour (a rendered markup string) is preserved.
- The renderer is injected as a new **optional** constructor argument (wired in `wmsettings.services.yml`), falling back to the `renderer` service — subclasses and swapped service definitions that don't pass it keep working unchanged.
- **`DeleteForm`**: declared the previously-undeclared dynamic `$id` property (dynamic properties are deprecated since PHP 8.2).

## Core requirement
`DeprecationHelper` only exists since **Drupal 10.1**, so `core_version_requirement`/composer narrow minimally from `^9.2 || ^10 | ^11` to `^10.1 || ^11` (also fixes the pre-existing single-pipe typo; no `^12` claim until D12 is released).

---
Found by a `drupal/upgrade_status` 5.x scan on Drupal 11.4 (intranet.uzleuven.be upgrade); every finding was re-verified against `main` HEAD before fixing, the pushed diff was independently re-reviewed, and the branch was exercised on a real 11.4 site (full PHPUnit + Playwright e2e suites green with the project pinned to this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EeazvHFUoYTXZGXAN5SZc
